### PR TITLE
Remove docker cache during build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
       }
       steps {
         script {
-          def dockerImage = docker.build 'linagora/esn-frontend-account'
+          def dockerImage = docker.build('linagora/esn-frontend-account', '--pull --no-cache .')
           docker.withRegistry('', 'dockerHub') {
             dockerImage.push('main')
           }
@@ -48,7 +48,7 @@ pipeline {
       }
       steps {
         script {
-          def dockerImage = docker.build 'linagora/esn-frontend-account'
+          def dockerImage = docker.build('linagora/esn-frontend-account', '--pull --no-cache .')
           docker.withRegistry('', 'dockerHub') {
             dockerImage.push(env.TAG_NAME)
           }


### PR DESCRIPTION
Needed, because docker will use cache, skipping the npm install step where the latest version of esn-frontend-common-libs is fetched